### PR TITLE
BS-317 Support building easy profiler with GCC < 5

### DIFF
--- a/easy_profiler_core/include/easy/details/easy_compiler_support.h
+++ b/easy_profiler_core/include/easy/details/easy_compiler_support.h
@@ -54,8 +54,10 @@
 #include <cstddef>
 
 // Required to get the iOS/tvOS simulator macros
-#if __has_include(<TargetConditionals.h>)
-#include <TargetConditionals.h>
+#ifdef __has_include
+# if __has_include(<TargetConditionals.h>)
+#  include <TargetConditionals.h>
+# endif
 #endif
 
 #if defined(_WIN32) && !defined(EASY_PROFILER_STATIC)


### PR DESCRIPTION
The `__has_include` preprocessor command is introduced in GCC 5.
Any platform building with GCC 4.x will error while building easy profiler because of this unguarded use of `__has_include`.